### PR TITLE
curses: fix compilation with ncurses-devel-6.1

### DIFF
--- a/pinentry/pinentry.h
+++ b/pinentry/pinentry.h
@@ -28,6 +28,8 @@ extern "C" {
 #endif
 #endif
 
+#undef ttytype
+
 typedef enum {
   PINENTRY_COLOR_NONE, PINENTRY_COLOR_DEFAULT,
   PINENTRY_COLOR_BLACK, PINENTRY_COLOR_RED,


### PR DESCRIPTION
/usr/include/ncursesw/curses.h is evil and #defines ttytype.