### PR TITLE
Add rpath so the Qt libs are found at runtime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,6 +556,7 @@ fi
 
 AC_SUBST(PINENTRY_QT_CFLAGS)
 AC_SUBST(PINENTRY_QT_LIBS)
+AC_SUBST(PINENTRY_QT_LDFLAGS)
 AC_SUBST(MOC)
 
 dnl If we have come so far, qt pinentry can be build.

--- a/m4/qt.m4
+++ b/m4/qt.m4
@@ -57,6 +57,11 @@ AC_DEFUN([FIND_QT],
       PINENTRY_QT_CFLAGS="$PINENTRY_QT_CFLAGS -std=c++11"
     fi
 
+    qtlibdir=`"$PKG_CONFIG" --variable libdir Qt5Core`
+    if test -n "$qtlibdir"; then
+        PINENTRY_QT_LDFLAGS="$PINENTRY_QT_LDFLAGS -Wl,-rpath \"$qtlibdir\""
+    fi
+
     AC_CHECK_TOOL(MOC, moc)
     AC_MSG_CHECKING([moc version])
     mocversion=`$MOC -v 2>&1`

--- a/qt/Makefile.am
+++ b/qt/Makefile.am
@@ -41,6 +41,7 @@ AM_CXXFLAGS = $(PINENTRY_QT_CFLAGS)
 pinentry_qt_LDADD = \
 	../pinentry/libpinentry.a $(top_builddir)/secmem/libsecmem.a \
 	$(COMMON_LIBS) $(PINENTRY_QT_LIBS) $(libcurses) $(LIBCAP)
+pinentry_qt_LDFLAGS = $(PINENTRY_QT_LDFLAGS)
 
 BUILT_SOURCES = \
 	pinentryconfirm.moc pinentrydialog.moc pinlineedit.moc


### PR DESCRIPTION
This is necessary when Qt is installed into a custom prefix.